### PR TITLE
Add CircleCI Build Testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2.1
+jobs:
+  build:
+    docker: 
+      - image: circleci/ruby:2.5.0
+    steps:
+      - checkout
+      - run:
+          name: "Install the dependencies"
+          command: bundle install --jobs=4 --retry=3
+      - run: 
+          name: "Run the specs"
+          command: bundle exec rake spec


### PR DESCRIPTION
I'm interested to see how CircleCI compares to TravisCI. This PR, plus enabling
the repo in the CircleCI webUI should be enough to view a build on the service